### PR TITLE
Export as ES2015 module

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,12 @@ module.exports = {
 }
 ```
 
+## Loader options
+
+### `esModule` : `boolean`
+
+Export Modernizr as ES2015 module. Usually required if you disable ES modules transform in Babel.
+
 ## Related
 
 - [Modernizr](https://github.com/Modernizr/Modernizr) - API for this module

--- a/index.js
+++ b/index.js
@@ -3,14 +3,20 @@
 const modernizr = require("modernizr");
 const loaderUtils = require("loader-utils");
 
-function wrapOutput(output) {
+function wrapOutput(output, asEsModule) {
   // Exposing Modernizr as a module.
+  if (asEsModule) {
+    return `var hadGlobal='Modernizr' in window;var oldGlobal=window.Modernizr;${output}export default window.Modernizr;if(hadGlobal){window.Modernizr=oldGlobal;}else{delete window.Modernizr;};`;
+  }
   return `;(function(window){var hadGlobal='Modernizr' in window;var oldGlobal=window.Modernizr;${output}module.exports=window.Modernizr;if(hadGlobal){window.Modernizr=oldGlobal;}else{delete window.Modernizr;}})(window);`;
 }
 
 module.exports = function() {
   const callback = this.async();
   const options = loaderUtils.getOptions(this) || {};
+  const esModule = options.esModule;
+
+  delete options.esModule;
 
   let userConfig = {};
 
@@ -27,5 +33,5 @@ module.exports = function() {
 
   const config = Object.assign({}, userConfig);
 
-  return modernizr.build(config, output => callback(null, wrapOutput(output)));
+  return modernizr.build(config, output => callback(null, wrapOutput(output, esModule)));
 };


### PR DESCRIPTION
This PR implements `esModule` option to make `webpack-modernizr-loader` compatible with tree-shaking-enabled environment.